### PR TITLE
[TH2-4729] Produce several StreamIDs from single source

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Read file common core for common (1.5.1)
+# Read file common core for common (2.0.0)
 
 That is the core part for file reads written in Java or Kotlin. It provides the following functionality:
 
@@ -169,6 +169,16 @@ The message will be dropped if the current state for StreamId contains **lastTim
 The file will be dropped if its last modification time is less than **lastTimestamp** for current StreamID + **staleTimeout**.
 
 ## Changes
+
+### 2.0.0
+
+**Breaking changes**
+
++ Source is now separated from StreamID. That allows produce more than one StreamID from a single source.
+  The implementation decides how to group sources in order to provide correct stream of messages.
++ The `DataGroupKey` interface was introduced. This is the key to groups sources.
+  The implementations of this interface must correctly implement `equals` and `hasCode` methods.
+  (because they can be used as a key in `Map`)
 
 ### 1.5.1
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 kotlin.code.style=official
 
-release_version=1.5.1
+release_version=2.0.0
 description = 'th2 common library for file read components (Java)'
 
 vcs_url=https://github.com/th2-net/th2-read-file-common-core

--- a/src/main/kotlin/com/exactpro/th2/read/file/common/ContentParser.kt
+++ b/src/main/kotlin/com/exactpro/th2/read/file/common/ContentParser.kt
@@ -19,7 +19,7 @@ package com.exactpro.th2.read.file.common
 
 import com.exactpro.th2.common.grpc.RawMessage
 
-interface ContentParser<in T> {
+interface ContentParser<in T, in K : DataGroupKey> {
 
     /**
      * @param considerNoFutureUpdates if it is `true` the source was not changed for a timeout
@@ -28,13 +28,13 @@ interface ContentParser<in T> {
      * @throws com.exactpro.th2.read.file.common.recovery.RecoverableException if the source needs to be reopen and recovered.
      * It is possible only if the source wrapper implements [com.exactpro.th2.read.file.common.recovery.RecoverableFileSourceWrapper]
      */
-    fun canParse(streamId: StreamId, source: T, considerNoFutureUpdates: Boolean): Boolean
+    fun canParse(dataGroup: K, source: T, considerNoFutureUpdates: Boolean): Boolean
 
     /**
-     * @return a collection of [RawMessage.Builder]s to be sent to the storage.
+     * @return a map between [StreamId] and collection of [RawMessage.Builder]s to be sent to the storage.
      *         If the collection is empty and more data can be parsed from the source
      *         another attempt to extract data will be performed
      */
-    fun parse(streamId: StreamId, source: T): Collection<RawMessage.Builder>
+    fun parse(dataGroup: K, source: T): Map<StreamId, Collection<RawMessage.Builder>>
 
 }

--- a/src/main/kotlin/com/exactpro/th2/read/file/common/DataGroupKey.kt
+++ b/src/main/kotlin/com/exactpro/th2/read/file/common/DataGroupKey.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Exactpro (Exactpro Systems Limited)
+ * Copyright 2023 Exactpro (Exactpro Systems Limited)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,9 +17,10 @@
 
 package com.exactpro.th2.read.file.common
 
-import com.exactpro.th2.common.grpc.RawMessage
-
-interface ReaderListener<in K : DataGroupKey> {
-    fun onStreamData(streamId: StreamId, messages: List<RawMessage.Builder>)
-    fun onError(dataGroup: K?, message: String, cause: Exception)
-}
+/**
+ * This is a marker interface for data group keys.
+ * It is used by [AbstractFileReader] to group files for processing.
+ *
+ * **The implementations must implement [Any.equals] and [Any.hashCode] methods and be suitable for [Map] keys**
+ */
+interface DataGroupKey

--- a/src/main/kotlin/com/exactpro/th2/read/file/common/ReadMessageFilter.kt
+++ b/src/main/kotlin/com/exactpro/th2/read/file/common/ReadMessageFilter.kt
@@ -18,6 +18,7 @@
 package com.exactpro.th2.read.file.common
 
 import com.exactpro.th2.common.grpc.RawMessageOrBuilder
+import com.exactpro.th2.read.file.common.state.GroupData
 import com.exactpro.th2.read.file.common.state.StreamData
 import java.nio.file.Path
 import java.time.Duration
@@ -38,14 +39,14 @@ interface ReadMessageFilter {
 
     /**
      * Returns `true` if the whole file should be dropped from processing
-     * @param streamId stream identificator
+     * @param groupKey data group identificator
      * @param fileInfo information about current file
-     * @param streamData state for the current [streamId]
+     * @param groupData state for the current [groupKey]
      */
     fun drop(
-        streamId: StreamId,
+        groupKey: DataGroupKey,
         fileInfo: FilterFileInfo,
-        streamData: StreamData?,
+        groupData: GroupData?,
     ): Boolean
 }
 

--- a/src/main/kotlin/com/exactpro/th2/read/file/common/impl/DelegateReaderListener.kt
+++ b/src/main/kotlin/com/exactpro/th2/read/file/common/impl/DelegateReaderListener.kt
@@ -18,18 +18,19 @@
 package com.exactpro.th2.read.file.common.impl
 
 import com.exactpro.th2.common.grpc.RawMessage
+import com.exactpro.th2.read.file.common.DataGroupKey
 import com.exactpro.th2.read.file.common.ReaderListener
 import com.exactpro.th2.read.file.common.StreamId
 
-class DelegateReaderListener(
+class DelegateReaderListener<in K : DataGroupKey>(
     private val onStreamDataDelegate: (StreamId, List<RawMessage.Builder>) -> Unit = { _, _ -> },
-    private val onErrorDelegate: (StreamId?, String, Exception) -> Unit = { _, _, _ -> },
-) : ReaderListener {
+    private val onErrorDelegate: (K?, String, Exception) -> Unit = { _, _, _ -> },
+) : ReaderListener<K> {
     override fun onStreamData(streamId: StreamId, messages: List<RawMessage.Builder>) {
         onStreamDataDelegate(streamId, messages)
     }
 
-    override fun onError(streamId: StreamId?, message: String, cause: Exception) {
-        onErrorDelegate(streamId, message, cause)
+    override fun onError(dataGroup: K?, message: String, cause: Exception) {
+        onErrorDelegate(dataGroup, message, cause)
     }
 }

--- a/src/main/kotlin/com/exactpro/th2/read/file/common/state/ReaderState.kt
+++ b/src/main/kotlin/com/exactpro/th2/read/file/common/state/ReaderState.kt
@@ -17,23 +17,35 @@
 
 package com.exactpro.th2.read.file.common.state
 
+import com.exactpro.th2.read.file.common.DataGroupKey
 import com.exactpro.th2.read.file.common.StreamId
 import com.google.protobuf.ByteString
 import java.nio.file.Path
 import java.time.Instant
 
-interface ReaderState {
-    fun isFileProcessed(streamId: StreamId, path: Path): Boolean
-    fun fileProcessed(streamId: StreamId, path: Path)
+interface ReaderState<in K : DataGroupKey> {
+    fun isFileProcessed(dataGroup: K, path: Path): Boolean
+    fun fileProcessed(dataGroup: K, path: Path)
     fun fileMoved(path: Path, current: Path): Boolean
     fun processedFilesRemoved(paths: Collection<Path>)
 
-    fun isStreamIdExcluded(streamId: StreamId): Boolean
-    fun excludeStreamId(streamId: StreamId)
+    fun isDataGroupExcluded(dataGroup: K): Boolean
+    fun excludeDataGroup(dataGroup: K)
+
+    operator fun get(dataGroup: K): GroupData?
+
+    operator fun set(dataGroup: K, groupData: GroupData)
 
     operator fun get(streamId: StreamId): StreamData?
     operator fun set(streamId: StreamId, data: StreamData)
 }
+
+data class GroupData(
+    /**
+     * The modification timestamp of the last processed source used by [DataGroupKey]
+     */
+    val lastSourceModificationTimestamp: Instant
+)
 
 data class StreamData(
     /**

--- a/src/test/kotlin/com/exactpro/th2/read/file/common/TestDirectoryChecker.kt
+++ b/src/test/kotlin/com/exactpro/th2/read/file/common/TestDirectoryChecker.kt
@@ -33,6 +33,9 @@ import java.nio.file.attribute.FileTime
 import java.util.Comparator
 
 internal class TestDirectoryChecker : AbstractFileTest() {
+    private data class TestGroup(val name: String) : DataGroupKey
+
+    private fun group(name: String) = TestGroup(name)
 
     @Test
     internal fun `retrieves first files`(@TempDir dest: Path) {
@@ -42,13 +45,13 @@ internal class TestDirectoryChecker : AbstractFileTest() {
         val directoryChecker = DirectoryChecker(
             dest,
             LAST_MODIFICATION_TIME_COMPARATOR.thenComparing { path -> path.nameParts().last().toInt() },
-            { path -> path.nameParts().firstOrNull()?.let { StreamId(it, Direction.FIRST) } }
+            { path -> path.nameParts().firstOrNull()?.let { TestGroup(it) } }
         )
         expectThat(directoryChecker.check())
             .isNotEmpty()
             .hasSize(2)
-            .hasEntry(StreamId("streamA", Direction.FIRST), dest.resolve("streamA-0"))
-            .hasEntry(StreamId("streamB", Direction.FIRST), dest.resolve("streamB-0"))
+            .hasEntry(group("streamA"), dest.resolve("streamA-0"))
+            .hasEntry(group("streamB"), dest.resolve("streamB-0"))
     }
 
     @Test
@@ -59,13 +62,13 @@ internal class TestDirectoryChecker : AbstractFileTest() {
         val directoryChecker = DirectoryChecker(
             dest,
             LAST_MODIFICATION_TIME_COMPARATOR.thenComparing { path -> path.nameParts().last().toInt() },
-            { path -> path.nameParts().firstOrNull()?.let { StreamId(it, Direction.FIRST) } },
+            { path -> path.nameParts().firstOrNull()?.let { group(it) } },
             { path -> path.fileName.toString().contains("streamA") }
         )
         expectThat(directoryChecker.check())
             .isNotEmpty()
             .hasSize(1)
-            .hasEntry(StreamId("streamA", Direction.FIRST), dest.resolve("streamA-0"))
+            .hasEntry(group("streamA"), dest.resolve("streamA-0"))
     }
 
     @Test
@@ -76,16 +79,16 @@ internal class TestDirectoryChecker : AbstractFileTest() {
         val directoryChecker = DirectoryChecker(
             dest,
             LAST_MODIFICATION_TIME_COMPARATOR.thenComparing { path -> path.nameParts().last().toInt() },
-            { path -> path.nameParts().firstOrNull()?.let { StreamId(it, Direction.FIRST) } }
+            { path -> path.nameParts().firstOrNull()?.let { group(it) } }
         )
 
-        val filterPath = { _: StreamId, path: Path -> path.nameParts().last().toInt() > 1 }
+        val filterPath = { _: TestGroup, path: Path -> path.nameParts().last().toInt() > 1 }
 
         expectThat(directoryChecker.check(filterPath))
             .isNotEmpty()
             .hasSize(2)
-            .hasEntry(StreamId("streamA", Direction.FIRST), dest.resolve("streamA-2"))
-            .hasEntry(StreamId("streamB", Direction.FIRST), dest.resolve("streamB-2"))
+            .hasEntry(group("streamA"), dest.resolve("streamA-2"))
+            .hasEntry(group("streamB"), dest.resolve("streamB-2"))
     }
 
     @Test
@@ -96,10 +99,10 @@ internal class TestDirectoryChecker : AbstractFileTest() {
         val directoryChecker = DirectoryChecker(
             dest,
             LAST_MODIFICATION_TIME_COMPARATOR.thenComparing { path -> path.nameParts().last().toInt() },
-            { path -> path.nameParts().firstOrNull()?.let { StreamId(it, Direction.FIRST) } }
+            { path -> path.nameParts().firstOrNull()?.let { group(it) } }
         )
 
-        val filterPath = { _: StreamId, path: Path -> path.nameParts().last().toInt() > 1 }
+        val filterPath = { _: TestGroup, path: Path -> path.nameParts().last().toInt() > 1 }
 
         expectThat(directoryChecker.check(filterPath)).isEmpty()
     }

--- a/src/test/kotlin/com/exactpro/th2/read/file/common/TestEndAwareFileSourceWrapper.kt
+++ b/src/test/kotlin/com/exactpro/th2/read/file/common/TestEndAwareFileSourceWrapper.kt
@@ -46,11 +46,11 @@ class TestEndAwareFileSourceWrapper : AbstractReaderTest() {
         )
     }
 
-    override fun createSource(id: StreamId, path: Path): FileSourceWrapper<BufferedReader> {
+    override fun createSource(id: StreamIdGroup, path: Path): FileSourceWrapper<BufferedReader> {
         return EndAwareBufferedReaderSource(EndAwareBufferedReader(path))
     }
 
-    override fun createParser(): ContentParser<BufferedReader> = EndAwareLineParser()
+    override fun createParser(): ContentParser<BufferedReader, StreamIdGroup> = EndAwareLineParser()
 
     @Test
     fun `closes source before stale timeout expired`() {
@@ -85,10 +85,11 @@ class TestEndAwareFileSourceWrapper : AbstractReaderTest() {
             }
     }
 
-    private class EndAwareLineParser : LineParser(
+    private class EndAwareLineParser : LineParser<StreamIdGroup>(
+        extractStreamId = { it, _ -> it.streamId },
         filter = { _, line -> line != END_MARKER }
     ) {
-        override fun canParse(streamId: StreamId, source: BufferedReader, considerNoFutureUpdates: Boolean): Boolean {
+        override fun canParse(dataGroup: StreamIdGroup, source: BufferedReader, considerNoFutureUpdates: Boolean): Boolean {
             val nextLine: String? = readNextPossibleLine(source, considerNoFutureUpdates)
             if (source.ready()) {
                 return true

--- a/src/test/kotlin/com/exactpro/th2/read/file/common/TestReaderDropsOldTimestamp.kt
+++ b/src/test/kotlin/com/exactpro/th2/read/file/common/TestReaderDropsOldTimestamp.kt
@@ -29,19 +29,13 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertTimeoutPreemptively
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
-import org.mockito.kotlin.doAnswer
-import org.mockito.kotlin.doReturn
-import org.mockito.kotlin.eq
 import org.mockito.kotlin.verify
-import org.mockito.kotlin.whenever
 import strikt.api.expectThat
 import strikt.assertions.get
 import strikt.assertions.hasSize
 import strikt.assertions.isEqualTo
 import strikt.assertions.single
 import java.io.BufferedReader
-import java.nio.file.Files
-import java.nio.file.attribute.BasicFileAttributes
 import java.time.Duration
 import java.time.Instant
 
@@ -113,12 +107,14 @@ internal class TestReaderDropsOldTimestamp : AbstractReaderTest() {
             .single().get { metadataBuilder }.get { timestamp }.isEqualTo(creationTime.toTimestamp())
     }
 
-    override fun createParser(): ContentParser<BufferedReader> {
-        return object : LineParser() {
-            override fun parse(streamId: StreamId, source: BufferedReader): Collection<RawMessage.Builder> {
-                return super.parse(streamId, source).onEach {
-                    val data = it.body.toStringUtf8()
-                    it.metadataBuilder.timestamp = Instant.parse(data).toTimestamp()
+    override fun createParser(): ContentParser<BufferedReader, StreamIdGroup> {
+        return object : LineParser<StreamIdGroup>(streamIdExtractor) {
+            override fun parse(dataGroup: StreamIdGroup, source: BufferedReader): Map<StreamId, Collection<RawMessage.Builder>> {
+                return super.parse(dataGroup, source).onEach { (_, msgs) ->
+                    msgs.onEach {
+                        val data = it.body.toStringUtf8()
+                        it.metadataBuilder.timestamp = Instant.parse(data).toTimestamp()
+                    }
                 }
             }
         }

--- a/src/test/kotlin/com/exactpro/th2/read/file/common/TestReaderFixTimestamp.kt
+++ b/src/test/kotlin/com/exactpro/th2/read/file/common/TestReaderFixTimestamp.kt
@@ -61,9 +61,10 @@ class TestReaderFixTimestamp : AbstractReaderTest() {
             }
         )
         doAnswer {
-            val source = it.arguments[1] as BufferedReader
+            val group = it.getArgument<StreamIdGroup>(0)
+            val source = it.getArgument<BufferedReader>(1)
             source.readLine()
-            return@doAnswer values
+            mapOf(group.streamId to values)
         }.whenever(parser).parse(any(), any())
 
         createFile(dir, "A-0").also {

--- a/src/test/kotlin/com/exactpro/th2/read/file/common/TestSameFileForDifferentStreamsInFileReader.kt
+++ b/src/test/kotlin/com/exactpro/th2/read/file/common/TestSameFileForDifferentStreamsInFileReader.kt
@@ -88,15 +88,15 @@ internal class TestSameFileForDifferentStreamsInFileReader : AbstractReaderTest(
         )
     }
 
-    override fun createExtractor(): (Path) -> Set<StreamId> {
+    override fun createExtractor(): (Path) -> Set<StreamIdGroup> {
         return { path ->
             val name = path.fileName.toString()
-            hashSetOf<StreamId>().apply {
+            hashSetOf<StreamIdGroup>().apply {
                 if (name.contains('A') || name.contains('C')) {
-                    add(StreamId("A", Direction.SECOND))
+                    add(StreamIdGroup(StreamId("A", Direction.SECOND)))
                 }
                 if (name.contains('B') || name.contains('C')) {
-                    add(StreamId("B", Direction.SECOND))
+                    add(StreamIdGroup(StreamId("B", Direction.SECOND)))
                 }
             }
         }


### PR DESCRIPTION
The current implementation associates the source with a single StreamID. It does not allow us to produce more than one StreamID from the source without opening it more than once.

Those changes are made to provide the such ability and decouple the source and StreamID